### PR TITLE
Add ControlPoint

### DIFF
--- a/lib/qmi/control_point.ex
+++ b/lib/qmi/control_point.ex
@@ -1,0 +1,21 @@
+defmodule QMI.ControlPoint do
+  @moduledoc """
+  A control point for sending QMI commands to a modem
+  """
+
+  @type client_id() :: non_neg_integer()
+
+  @type service() ::
+          QMI.Service.Control
+          | QMI.Service.DeviceManagement
+          | QMI.Service.NetworkAccess
+          | QMI.Service.WirelessData
+
+  @type t() :: %__MODULE__{
+          client_id: client_id(),
+          service: service(),
+          device: QMI.device()
+        }
+
+  defstruct client_id: nil, service: nil, device: nil
+end

--- a/lib/qmi/services/device_manangement.ex
+++ b/lib/qmi/services/device_manangement.ex
@@ -9,14 +9,14 @@ defmodule QMI.Service.DeviceManagement do
   The operating state mode should be `:online` before trying to make a wireless
   data network connection.
   """
-  def get_operating_state_mode(device, control_point) do
+  def get_operating_state_mode(device, service_client_id) do
     # Had to pad 3 bytes
     # output from `strace -x -o /data/qmicli-trace qmicli -d /dev/cdc-wdm0 --dms-get-operating-mode`
     # write(5, "\x01\x0c\x00\x00\x02\x01\x00\x01\x00\x2d\x00\x00\x00", 13) = 13
     # `\x2d` is the start of our request, and it shows that
     bin = <<@get_operating_state_mode::16-little, 0x00, 0x00, 0x00>>
 
-    QMI.Driver.request(device, bin, control_point)
+    QMI.Driver.request(device, bin, service_client_id)
   end
 
   @impl QMI.Service


### PR DESCRIPTION
The primary way to send messages to a modem is through what is called a
control point. A control point provides data on the device, service, and
the client id that is necessary for communication with the system
device.

Control points should be managed by consumers as there are times you
want to release the control point and there are times you want to hang
on to the control point. This should be an consumer level choice.

This PR introduces the control point data structure and updates the high
level `QMI` API to use it. However, I did not refactor the level low
APIs. For now we can abstract around the low level APIs until we have a
chance to refactor any of those if we want to. Doing it this way allows
me to continue supporting QMI VintageNet without having to refactor
everything. I will add and update other pieces as use cases show
themselves while implementing support in VintageNet for QMI.