### PR TITLE
Log indications

### DIFF
--- a/lib/qmi/driver.ex
+++ b/lib/qmi/driver.ex
@@ -134,7 +134,7 @@ defmodule QMI.Driver do
   end
 
   defp pop_and_reply(state, %Message{type: :indication} = msg) do
-    send(state.caller, {QMI, msg})
+    Logger.debug("QMI Indication: #{inspect(msg)}")
     state
   end
 


### PR DESCRIPTION
Currently indications are sent to the dynamic supervisor which logs an
error. Since we are not handling any indications right now this just
logs them at the debug level. This way it removes the error log from the
dynamic supervisor but retains the information for debugging as these
messages are useful. Also, at the debug level this should not add too much
noise for the SR hub fw logs unless you say to print logs at the
`:debug` level.