### PR TITLE
Fix Message.decode type discrepancies

### DIFF
--- a/lib/qmi/driver.ex
+++ b/lib/qmi/driver.ex
@@ -73,7 +73,17 @@ defmodule QMI.Driver do
   end
 
   def handle_info({:dev_bridge, ref, :read, data}, %{ref: ref} = state) do
-    handle_report(QMI.Message.decode(data), state)
+    case QMI.Message.decode(data) do
+      {:ok, message} ->
+        handle_report(message, state)
+
+      {:error, _reason} ->
+        Logger.warn(
+          "[QMI.Driver] #{state.device_path} invalid message from QMI: #{inspect(data)}"
+        )
+
+        {:noreply, state}
+    end
   end
 
   def handle_info({:dev_bridge, ref, :error, err}, %{ref: ref} = state) do


### PR DESCRIPTION
Message.decode could return an error tuple which was not being checked.
This changes the function to return an ok tuple on success and the
caller to check for ok or error. It also fixes some Dialyzer errors.
