### PR TITLE
Retry to open device after the dev bridge closes

### DIFF
--- a/lib/qmi/driver.ex
+++ b/lib/qmi/driver.ex
@@ -83,7 +83,11 @@ defmodule QMI.Driver do
   end
 
   def handle_info({:dev_bridge, ref, :error, err}, %{ref: ref} = state) do
-    Logger.error("[QMI.Driver] #{state.device_path} closed - #{inspect(err)}")
+    Logger.error("[QMI.Driver] #{state.device_path} - Error: #{inspect(err)}")
+    {:noreply, state}
+  end
+
+  def handle_info({:dev_bridge, ref, :closed}, %{ref: ref} = state) do
     {:noreply, state, {:continue, :open}}
   end
 


### PR DESCRIPTION
We were retrying to open the port process to the dev bridge when we were
notified that there was some error, often either `:enoent` or `:enodev`.
However, the way the dev bridge works is it notifies us about the error
then it closes. There was a condition that we when tried to close the
port in after being notified of the error, the port would close before
we called `Port.close/1` causing a bad argument error.

This change waits for the closed message before trying to reopen the
port to ensure that the state of the dev bridge does not have the old
port that has closed.