### PR TITLE
Create top-level supervision tree to isolate client IDs

### DIFF
--- a/lib/qmi/client_id_cache.ex
+++ b/lib/qmi/client_id_cache.ex
@@ -1,0 +1,46 @@
+defmodule QMI.ClientIDCache do
+  use GenServer
+
+  @moduledoc false
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(init_args) do
+    qmi = Keyword.fetch!(init_args, :name)
+
+    GenServer.start_link(__MODULE__, init_args, name: name(qmi))
+  end
+
+  @spec get_client_id(module(), non_neg_integer()) :: {:ok, non_neg_integer()} | {:error, atom()}
+  def get_client_id(qmi, service_id) do
+    GenServer.call(name(qmi), {:get_client_id, qmi, service_id})
+  end
+
+  defp name(qmi) do
+    Module.concat(qmi, ClientIDCache)
+  end
+
+  @impl GenServer
+  def init(_init_args) do
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:get_client_id, qmi, service_id}, _from, state) do
+    case state[service_id] do
+      nil ->
+        request = QMI.Codec.Control.get_client_id(service_id)
+
+        case QMI.Driver.call(qmi, 0, request) do
+          {:ok, client_id} ->
+            new_state = Map.put(state, service_id, client_id)
+            {:reply, {:ok, client_id}, new_state}
+
+          error ->
+            {:reply, error, state}
+        end
+
+      client_id ->
+        {:reply, {:ok, client_id}, state}
+    end
+  end
+end


### PR DESCRIPTION
Client IDs are pretty important and if you run out, then nothing works.
Since it's possible for the driver to crash, we want to be able to
restart it without losing client IDs. This puts the driver and client ID
in different branches of the supervision tree so unless things get
really bad, they won't be lost.
