### PR TITLE
User error from an failed QMI command

### DIFF
--- a/lib/qmi/driver.ex
+++ b/lib/qmi/driver.ex
@@ -182,7 +182,7 @@ defmodule QMI.Driver do
     {:noreply, %{state | transactions: transactions}}
   end
 
-  defp handle_report(%{transaction_id: transaction_id, code: error}, state) do
+  defp handle_report(%{transaction_id: transaction_id, code: :failure, error: error}, state) do
     {:noreply, fail_transaction_id(state, transaction_id, error)}
   end
 


### PR DESCRIPTION
This improves the error messages from:

```elixir
16:44:31.606 [warn]  [VintageNetQMI]: could not connect for :failure.
```

to something with more information:

```elixir
16:44:31.606 [warn]  [VintageNetQMI]: could not connect for :call_failed.
```