### PR TITLE
Fix documentation warnings

### DIFF
--- a/lib/qmi/codec/indication.ex
+++ b/lib/qmi/codec/indication.ex
@@ -1,7 +1,7 @@
 defmodule QMI.Codec.Indication do
-  @moduledoc """
-  Parse an indication from QMI
-  """
+  @moduledoc false
+
+  # Parser for indications
 
   @doc """
   Route the indication to the appropriate parser.


### PR DESCRIPTION
The `QMI.Message` module is private so when building docs there was a
warning about the `QMI.Message.t()` type missing or set to private. This
changes the `QMI.Codec.Indication` module to be private and so when
referencing the message type the warnings goes away.
