### PR TITLE
DeviceManagement service manufacturer, model, hardware rev

### DIFF
--- a/lib/qmi/codec/device_management.ex
+++ b/lib/qmi/codec/device_management.ex
@@ -3,7 +3,20 @@ defmodule QMI.Codec.DeviceManagement do
   Codec for making device management requests
   """
 
+  @get_device_mfr 0x0021
   @get_device_rev_id 0x0023
+
+  @doc """
+  Get the device manufacturer
+  """
+  @spec get_device_mfr() :: QMI.request()
+  def get_device_mfr() do
+    %{
+      service_id: 0x02,
+      payload: [<<@get_device_mfr::16-little, 0, 0>>],
+      decode: &parse_get_device_mfr/1
+    }
+  end
 
   @doc """
   Get the firmware revision id
@@ -15,6 +28,13 @@ defmodule QMI.Codec.DeviceManagement do
       payload: [<<0x23::16-little, 0x00, 0x00>>],
       decode: &parse_get_device_rev_id/1
     }
+  end
+
+  defp parse_get_device_mfr(
+         <<@get_device_mfr::16-little, _size::16-little, _result_tlv::7*8, 1, len::16-little,
+           mfr::size(len)-binary>>
+       ) do
+    {:ok, mfr}
   end
 
   defp parse_get_device_rev_id(<<@get_device_rev_id::16-little, _size::16-little, tlvs::binary>>) do

--- a/lib/qmi/codec/device_management.ex
+++ b/lib/qmi/codec/device_management.ex
@@ -6,6 +6,19 @@ defmodule QMI.Codec.DeviceManagement do
   @get_device_mfr 0x0021
   @get_device_model_id 0x0022
   @get_device_rev_id 0x0023
+  @get_device_hardware_rev 0x002C
+
+  @doc """
+  Get the device hardware revision
+  """
+  @spec get_device_hardware_rev() :: QMI.request()
+  def get_device_hardware_rev() do
+    %{
+      service_id: 0x02,
+      payload: [<<@get_device_hardware_rev::16-little, 0, 0>>],
+      decode: &parse_get_device_hardware_rev/1
+    }
+  end
 
   @doc """
   Get the device manufacturer
@@ -41,6 +54,13 @@ defmodule QMI.Codec.DeviceManagement do
       payload: [<<0x23::16-little, 0x00, 0x00>>],
       decode: &parse_get_device_rev_id/1
     }
+  end
+
+  defp parse_get_device_hardware_rev(
+         <<@get_device_hardware_rev::16-little, _size::16-little, _result_tlv::7*8, 1,
+           len::16-little, hardware_rev::size(len)-binary>>
+       ) do
+    {:ok, hardware_rev}
   end
 
   defp parse_get_device_mfr(

--- a/lib/qmi/codec/device_management.ex
+++ b/lib/qmi/codec/device_management.ex
@@ -4,6 +4,7 @@ defmodule QMI.Codec.DeviceManagement do
   """
 
   @get_device_mfr 0x0021
+  @get_device_model_id 0x0022
   @get_device_rev_id 0x0023
 
   @doc """
@@ -15,6 +16,18 @@ defmodule QMI.Codec.DeviceManagement do
       service_id: 0x02,
       payload: [<<@get_device_mfr::16-little, 0, 0>>],
       decode: &parse_get_device_mfr/1
+    }
+  end
+
+  @doc """
+  Get the device model
+  """
+  @spec get_device_model_id() :: QMI.request()
+  def get_device_model_id() do
+    %{
+      service_id: 0x02,
+      payload: [<<@get_device_model_id::16-little, 0, 0>>],
+      decode: &parse_get_device_model_id/1
     }
   end
 
@@ -35,6 +48,13 @@ defmodule QMI.Codec.DeviceManagement do
            mfr::size(len)-binary>>
        ) do
     {:ok, mfr}
+  end
+
+  defp parse_get_device_model_id(
+         <<@get_device_model_id::16-little, _size::16-little, _result_tlv::7*8, 1, len::16-little,
+           model::size(len)-binary>>
+       ) do
+    {:ok, model}
   end
 
   defp parse_get_device_rev_id(<<@get_device_rev_id::16-little, _size::16-little, tlvs::binary>>) do

--- a/lib/qmi/device_management.ex
+++ b/lib/qmi/device_management.ex
@@ -22,4 +22,13 @@ defmodule QMI.DeviceManagement do
     Codec.DeviceManagement.get_device_mfr()
     |> QMI.call(qmi)
   end
+
+  @doc """
+  Get the device model information
+  """
+  @spec get_model(QMI.name()) :: {:ok, binary()} | {:error, any()}
+  def get_model(qmi) do
+    Codec.DeviceManagement.get_device_model_id()
+    |> QMI.call(qmi)
+  end
 end

--- a/lib/qmi/device_management.ex
+++ b/lib/qmi/device_management.ex
@@ -6,6 +6,15 @@ defmodule QMI.DeviceManagement do
   alias QMI.Codec
 
   @doc """
+  Get the hardware information
+  """
+  @spec get_hardware_rev(QMI.name()) :: {:ok, map()} | {:error, any()}
+  def get_hardware_rev(qmi) do
+    Codec.DeviceManagement.get_device_hardware_rev()
+    |> QMI.call(qmi)
+  end
+
+  @doc """
   Get the firmware information
   """
   @spec get_firmware_rev(QMI.name()) :: {:ok, map()} | {:error, any()}

--- a/lib/qmi/device_management.ex
+++ b/lib/qmi/device_management.ex
@@ -13,4 +13,13 @@ defmodule QMI.DeviceManagement do
     Codec.DeviceManagement.get_device_rev_id()
     |> QMI.call(qmi)
   end
+
+  @doc """
+  Get the device manufacturer information
+  """
+  @spec get_manufacturer(QMI.name()) :: {:ok, binary()} | {:error, any()}
+  def get_manufacturer(qmi) do
+    Codec.DeviceManagement.get_device_mfr()
+    |> QMI.call(qmi)
+  end
 end

--- a/test/qmi/codec/device_management_test.exs
+++ b/test/qmi/codec/device_management_test.exs
@@ -29,4 +29,18 @@ defmodule QMI.Codec.DeviceManagementTest do
 
     assert request.decode.(response_bin) == {:ok, "QUALCOMM INCORPORATED"}
   end
+
+  test "get_device_model_id/0" do
+    request = DeviceManagement.get_device_model_id()
+
+    assert IO.iodata_to_binary(request.payload) == <<34, 0, 0, 0>>
+    assert request.service_id == 0x02
+
+    response_bin =
+      <<34, 0, 40, 0, 2, 4, 0, 0, 0, 0, 0, 1, 31, 0, 81, 85, 69, 67, 84, 69, 76, 32, 77, 111, 98,
+        105, 108, 101, 32, 66, 114, 111, 97, 100, 98, 97, 110, 100, 32, 77, 111, 100, 117, 108,
+        101>>
+
+    assert request.decode.(response_bin) == {:ok, "QUECTEL Mobile Broadband Module"}
+  end
 end

--- a/test/qmi/codec/device_management_test.exs
+++ b/test/qmi/codec/device_management_test.exs
@@ -16,4 +16,17 @@ defmodule QMI.Codec.DeviceManagementTest do
                0x3A, 0x30, 0x30, 0x3A, 0x30, 0x30, 0x5D>>
            ) == {:ok, "25.20.266  1  [Jun 21 2019 13:00:00]"}
   end
+
+  test "get_device_mfr/0" do
+    request = DeviceManagement.get_device_mfr()
+
+    assert IO.iodata_to_binary(request.payload) == <<33, 0, 0, 0>>
+    assert request.service_id == 0x02
+
+    response_bin =
+      <<33, 0, 31, 0, 2, 4, 0, 0, 0, 0, 0, 1, 21, 0, 81, 85, 65, 76, 67, 79, 77, 77, 32, 73, 78,
+        67, 79, 82, 80, 79, 82, 65, 84, 69, 68>>
+
+    assert request.decode.(response_bin) == {:ok, "QUALCOMM INCORPORATED"}
+  end
 end

--- a/test/qmi/codec/device_management_test.exs
+++ b/test/qmi/codec/device_management_test.exs
@@ -43,4 +43,15 @@ defmodule QMI.Codec.DeviceManagementTest do
 
     assert request.decode.(response_bin) == {:ok, "QUECTEL Mobile Broadband Module"}
   end
+
+  test "get_device_hardware_rev/0" do
+    request = DeviceManagement.get_device_hardware_rev()
+
+    assert IO.iodata_to_binary(request.payload) == <<44, 0, 0, 0>>
+    assert request.service_id == 0x02
+
+    response_bin = <<44, 0, 40, 0, 2, 4, 0, 0, 0, 0, 0, 1, 5, 0, 49, 48, 48, 48, 48>>
+
+    assert request.decode.(response_bin) == {:ok, "10000"}
+  end
 end


### PR DESCRIPTION
Resolves #55 (plus a few extra 😉 )

* `QMI.DeviceManagement.get_manufacturer/1`
* `QMI.DeviceManagement.get_model/1`
* `QMI.DeviceManagement.get_hardware_rev/1`