### PR TITLE
Add `:name` to packet status indication

### DIFF
--- a/lib/qmi/codec/wireless_data.ex
+++ b/lib/qmi/codec/wireless_data.ex
@@ -42,6 +42,7 @@ defmodule QMI.Codec.WirelessData do
   The indication for a change in the current packet data connection status
   """
   @type packet_status_indication() :: %{
+          name: :packet_status_indication,
           status: :disconnected | :connected | :suspended | :authenticating,
           reconfiguration_required: boolean(),
           call_end_reason: integer() | nil,
@@ -123,6 +124,7 @@ defmodule QMI.Codec.WirelessData do
 
   defp packet_status_indication_init() do
     %{
+      name: :packet_status_indication,
       status: nil,
       reconfiguration_required: nil,
       call_end_reason: nil,


### PR DESCRIPTION
With other supported indications we report the indication name. This
will allow for a consuming library to match on the name to make logical
decisions about what to do with the indication.
