### PR TITLE
Fix TX/RX stats when stat value is missing

### DIFF
--- a/test/qmi/codec/wireless_data_test.exs
+++ b/test/qmi/codec/wireless_data_test.exs
@@ -297,12 +297,12 @@ defmodule QMI.Codec.WirelessDataTest do
             %{
               name: :event_report_indication,
               rx_bytes: 896,
-              rx_errors: 4_294_967_295,
-              rx_overflows: 4_294_967_295,
+              rx_errors: 0,
+              rx_overflows: 0,
               rx_packets: 16,
               tx_bytes: 1520,
-              tx_errors: 4_294_967_295,
-              tx_overflows: 4_294_967_295,
+              tx_errors: 0,
+              tx_overflows: 0,
               tx_packets: 28
             }} ==
              WirelessData.parse_indication(binary)


### PR DESCRIPTION
When the stat value for a TX/RX stat is missing QMI reports back
`0xFFFFFFFF`, so we mark that is `0`.

This happens because the wireless data service event report was
configured to report those stats, but those stats have not be recorded
yet.

We use libqmi as a reference point for this:
https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/blob/master/src/qmicli/qmicli-wds.c#L1068-1091
