### PR TITLE
v0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.10.0] - 2024-07-25
+
+## Changed
+
+* Trim invalid characters from `QMI_NAS_GET_SYS_INFO` MCC and MNC values
+
 ## [v0.9.0] - 2024-07-25
 
 ## Changed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule QMI.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.10.0"
   @source_url "https://github.com/nerves-networking/qmi"
 
   def project do


### PR DESCRIPTION
## [v0.10.0] - 2024-07-25

## Changed

* Trim invalid characters from `QMI_NAS_GET_SYS_INFO` MCC and MNC values