### PR TITLE
More gracefully handle a shutdown race

### DIFF
--- a/lib/qmi/client_id_cache.ex
+++ b/lib/qmi/client_id_cache.ex
@@ -12,6 +12,8 @@ defmodule QMI.ClientIDCache do
   @spec get_client_id(module(), non_neg_integer()) :: {:ok, non_neg_integer()} | {:error, atom()}
   def get_client_id(qmi, service_id) do
     GenServer.call(name(qmi), {:get_client_id, qmi, service_id})
+  catch
+    :exit, {:noproc, _} -> {:error, :qmi_interface_down}
   end
 
   defp name(qmi) do


### PR DESCRIPTION
It seems like there's a race when shutting down a QMI interface where a
latent request will call `ClientIDCache.get_client_id/2`. This change
results in an error rather than an exception which seems like it should
let things shutdown with less noise. This is not a common event.
