### PR TITLE
Add extended QMI service support: WDA, UIM provisioning, WDS profiles, and improved error handling

### DIFF
--- a/lib/qmi.ex
+++ b/lib/qmi.ex
@@ -68,7 +68,13 @@ defmodule QMI do
     # This might not be true for all modems as some support 802.3 IP framing,
     # however, on the EC25 supports raw IP framing. This feature can be detected
     # and is probably a better solution that just forcing the raw IP framing.
-    File.write!("/sys/class/net/#{ifname}/qmi/raw_ip", "Y")
+    path = "/sys/class/net/#{ifname}/qmi/raw_ip"
+
+    if File.exists?(path) do
+      File.write!(path, "Y")
+    else
+      :ok
+    end
   end
 
   @doc """

--- a/lib/qmi.ex
+++ b/lib/qmi.ex
@@ -81,11 +81,15 @@ defmodule QMI do
   Send a request over QMI and return the response
 
   NOTE: the QMI name parameter is second to facilitate piping
+
+  ## Options
+
+  * `:timeout` - override the default 5 second call timeout (in milliseconds)
   """
-  @spec call(request(), name()) :: any()
-  def call(request, qmi) do
+  @spec call(request(), name(), keyword()) :: any()
+  def call(request, qmi, opts \\ []) do
     with {:ok, client_id} <- QMI.ClientIDCache.get_client_id(qmi, request.service_id) do
-      QMI.Driver.call(qmi, client_id, request)
+      QMI.Driver.call(qmi, client_id, request, opts)
     end
   end
 end

--- a/lib/qmi/codec/user_identity.ex
+++ b/lib/qmi/codec/user_identity.ex
@@ -9,6 +9,8 @@ defmodule QMI.Codec.UserIdentity do
   """
 
   @read_transparent 0x0020
+  @get_card_status 0x002F
+  @change_uim_session 0x0038
 
   @typedoc """
   The response from issuing a read transparent request
@@ -82,5 +84,183 @@ defmodule QMI.Codec.UserIdentity do
 
   defp parse_tlvs(result, <<_type, size::little-16, _values::binary-size(size), rest::binary>>) do
     parse_tlvs(result, rest)
+  end
+
+  @doc """
+  Provision a UIM session for a specific application.
+
+  This creates a session context for communicating with a specific application
+  on a particular card slot.
+  """
+  @spec provision_uim_session(non_neg_integer(), binary()) :: QMI.request()
+  def provision_uim_session(slot_id, application_id) do
+    application_information_tlv = application_information_tlv(slot_id, application_id)
+    session_change_tlv = session_change_tlv()
+    tlvs = <<application_information_tlv::binary, session_change_tlv::binary>>
+    size = byte_size(tlvs)
+
+    %{
+      service_id: 0x0B,
+      payload: [<<@change_uim_session::little-16, size::little-16>>, tlvs],
+      decode: &parse_provisioning_response/1
+    }
+  end
+
+  defp application_information_tlv(slot_id, application_id) do
+    aid_len = byte_size(application_id)
+
+    <<0x10, aid_len + 2::little-16, slot_id::8, aid_len::8, application_id::binary>>
+  end
+
+  # TLV 0x01: Session change
+  # session_type = 0x00 (primary GW provisioning), activate = 0x01
+  defp session_change_tlv() do
+    <<0x01, 0x02::little-16, 0x00, 0x01>>
+  end
+
+  defp parse_provisioning_response(
+         <<@change_uim_session::little-16, _tlv_length::little-16, 0x02, _value_length::little-16,
+           0x00, 0x00, 0x00, 0x00>>
+       ) do
+    :ok
+  end
+
+  defp parse_provisioning_response(<<@change_uim_session::little-16, _rest::binary>>) do
+    {:error, :provisioning_failed}
+  end
+
+  @doc """
+  Get the status of all card slots in the device.
+
+  This command retrieves information about all available card slots and their current state.
+  """
+  @spec get_cards_status() :: QMI.request()
+  def get_cards_status() do
+    %{
+      service_id: 0x0B,
+      payload: [<<@get_card_status::16-little, 0x00, 0x00>>],
+      decode: &parse_card_status_response/1
+    }
+  end
+
+  defp parse_card_status_response(
+         <<@get_card_status::little-16, _length::little-16, tlvs::binary>>
+       ) do
+    result = %{
+      index_gw_primary: nil,
+      index_1x_primary: nil,
+      index_gw_secondary: nil,
+      index_1x_secondary: nil,
+      cards: []
+    }
+
+    parse_card_status_tlvs(result, tlvs)
+  end
+
+  defp parse_card_status_tlvs(
+         result,
+         <<0x10, length::little-16, content::binary-size(length), tlvs::binary>>
+       ) do
+    parse_cards_tlv(result, content)
+    |> parse_card_status_tlvs(tlvs)
+  end
+
+  defp parse_card_status_tlvs(result, <<0x10, length::little-16, content::binary-size(length)>>) do
+    parse_cards_tlv(result, content)
+  end
+
+  defp parse_card_status_tlvs(
+         result,
+         <<_type, length::little-16, _content::binary-size(length), tlvs::binary>>
+       ) do
+    parse_card_status_tlvs(result, tlvs)
+  end
+
+  defp parse_card_status_tlvs(result, <<>>) do
+    {:ok, result}
+  end
+
+  defp parse_cards_tlv(result, content) do
+    <<index_gw_primary::little-16, index_1x_primary::little-16, index_gw_secondary::little-16,
+      index_1x_secondary::little-16, cards_count::8, rest::binary>> = content
+
+    result
+    |> Map.put(:index_gw_primary, index_gw_primary)
+    |> Map.put(:index_1x_primary, index_1x_primary)
+    |> Map.put(:index_gw_secondary, index_gw_secondary)
+    |> Map.put(:index_1x_secondary, index_1x_secondary)
+    |> parse_cards(cards_count, rest, 1)
+  end
+
+  defp parse_cards(result, 0, _rest, _slot_id) do
+    result
+  end
+
+  defp parse_cards(
+         result,
+         n,
+         <<
+           card_state::8,
+           upin_state::8,
+           upin_retries::8,
+           upuk_retries::8,
+           error_code::8,
+           num_apps::8,
+           rest::binary
+         >>,
+         slot_id
+       ) do
+    card = %{
+      slot_id: slot_id,
+      card_state: card_state,
+      upin_state: upin_state,
+      upin_retries: upin_retries,
+      upuk_retries: upuk_retries,
+      error_code: error_code,
+      num_apps: num_apps
+    }
+
+    {applications, rest_after_apps} = parse_applications(rest, num_apps)
+    updated_card = card |> Map.put(:applications, applications)
+    updated_result = Map.update!(result, :cards, fn cards -> [updated_card | cards] end)
+    parse_cards(updated_result, n - 1, rest_after_apps, slot_id + 1)
+  end
+
+  defp parse_applications(rest, num_apps) do
+    parse_application([], num_apps, rest)
+  end
+
+  defp parse_application(result, 0, rest) do
+    {Enum.reverse(result), rest}
+  end
+
+  defp parse_application(
+         result,
+         n,
+         <<app_type::8, app_state::8, personalization_state::8, personalization_feature::8,
+           personalization_retries::8, personalization_unblock_retries::8, aid_len::8,
+           aid::binary-size(aid_len), upin_replaces_pin1::8, pin1_state::8, pin1_retries::8,
+           puk1_retries::8, pin2_state::8, pin2_retries::8, puk2_retries::8,
+           rest_after_app::binary>>
+       ) do
+    app = %{
+      type: app_type,
+      state: app_state,
+      personalization_state: personalization_state,
+      personalization_feature: personalization_feature,
+      personalization_retries: personalization_retries,
+      personalization_unblock_retries: personalization_unblock_retries,
+      aid: aid,
+      upin_replaces_pin1: upin_replaces_pin1,
+      pin1_state: pin1_state,
+      pin1_retries: pin1_retries,
+      puk1_retries: puk1_retries,
+      pin2_state: pin2_state,
+      pin2_retries: pin2_retries,
+      puk2_retries: puk2_retries
+    }
+
+    updated_result = [app | result]
+    parse_application(updated_result, n - 1, rest_after_app)
   end
 end

--- a/lib/qmi/codec/wireless_data.ex
+++ b/lib/qmi/codec/wireless_data.ex
@@ -44,12 +44,13 @@ defmodule QMI.Codec.WirelessData do
           :unspecified
           | :mobile_ip
           | :internal
-          | :call_manger_defined
+          | :call_manager_defined
           | :three_gpp_specification_defined
           | :ppp
           | :ehrpd
           | :ipv6
           | :handoff
+          | {:unknown, non_neg_integer()}
 
   @typedoc """
   Name of the technology
@@ -299,6 +300,7 @@ defmodule QMI.Codec.WirelessData do
   defp parse_call_end_reason_type(0x08), do: :ehrpd
   defp parse_call_end_reason_type(0x09), do: :ipv6
   defp parse_call_end_reason_type(0x0C), do: :handoff
+  defp parse_call_end_reason_type(other), do: {:unknown, other}
 
   @spec parse_event_report_indication(event_report_indication(), binary()) ::
           event_report_indication()

--- a/lib/qmi/codec/wireless_data_admin.ex
+++ b/lib/qmi/codec/wireless_data_admin.ex
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 Marc Lainez
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule QMI.Codec.WirelessDataAdmin do
+  @moduledoc """
+  Codec for the QMI WDA (Wireless Data Administrative) service.
+
+  The WDA service configures the data format used between the modem and the
+  host driver.  On modems whose `qmi_wwan` driver does not expose
+  `/sys/class/net/<ifname>/qmi/raw_ip`, this is the only way to switch the
+  data path between 802.3 (Ethernet) framing and raw-IP framing.
+  """
+
+  @wda_service_id 0x1A
+
+  @set_data_format 0x0020
+  @get_data_format 0x0021
+
+  @typedoc """
+  Link-layer protocol for the data path.
+
+  * `:raw_ip` – raw IP packets (no Ethernet header)
+  * `:"802.3"` – Ethernet-framed packets
+  """
+  @type link_layer_protocol :: :raw_ip | :"802.3" | :unknown
+
+  @typedoc """
+  Data aggregation protocol.
+
+  * `:disabled` – no aggregation
+  * `:qmap_v1` – QMAP version 1
+  * `:qmap_v5` – QMAP version 5
+  """
+  @type aggregation_protocol :: :disabled | :qmap_v1 | :qmap_v5 | :unknown
+
+  @typedoc """
+  Result of `get_data_format/0` or `set_data_format/1`.
+  """
+  @type data_format :: %{
+          optional(:qos_format) => boolean(),
+          optional(:link_layer_protocol) => link_layer_protocol(),
+          optional(:ul_aggregation_protocol) => aggregation_protocol(),
+          optional(:dl_aggregation_protocol) => aggregation_protocol(),
+          optional(:dl_max_datagrams) => non_neg_integer(),
+          optional(:dl_max_size) => non_neg_integer()
+        }
+
+  @typedoc """
+  Options for `set_data_format/1`.
+
+  * `:link_layer_protocol` – `:raw_ip` or `:"802.3"` (required)
+  * `:ul_aggregation_protocol` – uplink aggregation (default `:disabled`)
+  * `:dl_aggregation_protocol` – downlink aggregation (default `:disabled`)
+  * `:qos_format` – whether to include QoS headers (default `false`)
+  * `:endpoint_type` – endpoint device type (default `2` for HSUSB)
+  * `:endpoint_iface_number` – interface number on the endpoint
+  """
+  @type set_data_format_opt ::
+          {:link_layer_protocol, link_layer_protocol()}
+          | {:ul_aggregation_protocol, aggregation_protocol()}
+          | {:dl_aggregation_protocol, aggregation_protocol()}
+          | {:qos_format, boolean()}
+          | {:endpoint_type, non_neg_integer()}
+          | {:endpoint_iface_number, non_neg_integer()}
+
+  # -- Public API ------------------------------------------------------------
+
+  @doc """
+  Build a request to query the current data format.
+  """
+  @spec get_data_format() :: QMI.request()
+  def get_data_format do
+    %{
+      service_id: @wda_service_id,
+      payload: [<<@get_data_format::little-16, 0::little-16>>],
+      decode: &parse_data_format_response(@get_data_format, &1)
+    }
+  end
+
+  @doc """
+  Build a request to set the data format.
+
+  ## Examples
+
+      QMI.Codec.WirelessDataAdmin.set_data_format(link_layer_protocol: :raw_ip)
+  """
+  @spec set_data_format([set_data_format_opt()]) :: QMI.request()
+  def set_data_format(opts) do
+    {tlvs, size} = build_set_data_format_tlvs(opts, [], 0)
+
+    %{
+      service_id: @wda_service_id,
+      payload: [<<@set_data_format::little-16, size::little-16>>, tlvs],
+      decode: &parse_data_format_response(@set_data_format, &1)
+    }
+  end
+
+  # -- TLV builders ----------------------------------------------------------
+
+  defp build_set_data_format_tlvs([], tlvs, size), do: {tlvs, size}
+
+  defp build_set_data_format_tlvs([{:qos_format, qos?} | rest], tlvs, size) do
+    val = if qos?, do: 1, else: 0
+    tlv = <<0x10, 0x01::little-16, val>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs([{:link_layer_protocol, proto} | rest], tlvs, size) do
+    val = encode_link_layer_protocol(proto)
+    tlv = <<0x11, 0x04::little-16, val::little-32>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs([{:ul_aggregation_protocol, proto} | rest], tlvs, size) do
+    val = encode_aggregation_protocol(proto)
+    tlv = <<0x12, 0x04::little-16, val::little-32>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs([{:dl_aggregation_protocol, proto} | rest], tlvs, size) do
+    val = encode_aggregation_protocol(proto)
+    tlv = <<0x13, 0x04::little-16, val::little-32>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs(
+         [{:endpoint_type, type} | rest],
+         tlvs,
+         size
+       ) do
+    # TLV 0x17: Endpoint info — we store type now, iface_number comes next
+    # This is handled specially: we look ahead for :endpoint_iface_number
+    {iface_number, rest} = pop_opt(rest, :endpoint_iface_number, 0)
+    tlv = <<0x17, 0x08::little-16, type::little-32, iface_number::little-32>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs([{:endpoint_iface_number, iface_number} | rest], tlvs, size) do
+    # If endpoint_iface_number appears without endpoint_type before it,
+    # default endpoint_type to 2 (HSUSB)
+    tlv = <<0x17, 0x08::little-16, 2::little-32, iface_number::little-32>>
+    build_set_data_format_tlvs(rest, [tlvs, tlv], size + byte_size(tlv))
+  end
+
+  defp build_set_data_format_tlvs([_unknown | rest], tlvs, size) do
+    build_set_data_format_tlvs(rest, tlvs, size)
+  end
+
+  defp pop_opt(opts, key, default) do
+    case Keyword.pop(opts, key) do
+      {nil, rest} -> {default, rest}
+      {val, rest} -> {val, rest}
+    end
+  end
+
+  # -- Response parsing ------------------------------------------------------
+
+  defp parse_data_format_response(
+         msg_id,
+         <<msg_id::little-16, _size::little-16, 0x02, _result_len::little-16, 0x00::little-16,
+           0x00::little-16, rest::binary>>
+       ) do
+    {:ok, parse_data_format_tlvs(rest, %{})}
+  end
+
+  defp parse_data_format_response(
+         msg_id,
+         <<msg_id::little-16, _size::little-16, 0x02, _result_len::little-16,
+           _qmi_error::little-16, error_code::little-16, _rest::binary>>
+       ) do
+    {:error, QMI.Codes.decode_error_code(error_code)}
+  end
+
+  defp parse_data_format_response(_msg_id, _bin) do
+    {:error, :parse_error}
+  end
+
+  # -- Optional TLV parsing --------------------------------------------------
+
+  defp parse_data_format_tlvs(<<>>, acc), do: acc
+
+  defp parse_data_format_tlvs(
+         <<0x10, 0x01::little-16, qos, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(rest, Map.put(acc, :qos_format, qos != 0))
+  end
+
+  defp parse_data_format_tlvs(
+         <<0x11, 0x04::little-16, proto::little-32, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(
+      rest,
+      Map.put(acc, :link_layer_protocol, decode_link_layer_protocol(proto))
+    )
+  end
+
+  defp parse_data_format_tlvs(
+         <<0x12, 0x04::little-16, proto::little-32, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(
+      rest,
+      Map.put(acc, :ul_aggregation_protocol, decode_aggregation_protocol(proto))
+    )
+  end
+
+  defp parse_data_format_tlvs(
+         <<0x13, 0x04::little-16, proto::little-32, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(
+      rest,
+      Map.put(acc, :dl_aggregation_protocol, decode_aggregation_protocol(proto))
+    )
+  end
+
+  defp parse_data_format_tlvs(
+         <<0x15, 0x04::little-16, max_datagrams::little-32, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(rest, Map.put(acc, :dl_max_datagrams, max_datagrams))
+  end
+
+  defp parse_data_format_tlvs(
+         <<0x16, 0x04::little-16, max_size::little-32, rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(rest, Map.put(acc, :dl_max_size, max_size))
+  end
+
+  # Skip unknown TLVs
+  defp parse_data_format_tlvs(
+         <<_tag, len::little-16, _value::binary-size(len), rest::binary>>,
+         acc
+       ) do
+    parse_data_format_tlvs(rest, acc)
+  end
+
+  # -- Encoders / Decoders ---------------------------------------------------
+
+  defp encode_link_layer_protocol(:raw_ip), do: 2
+  defp encode_link_layer_protocol(:"802.3"), do: 1
+
+  defp decode_link_layer_protocol(1), do: :"802.3"
+  defp decode_link_layer_protocol(2), do: :raw_ip
+  defp decode_link_layer_protocol(_), do: :unknown
+
+  defp encode_aggregation_protocol(:disabled), do: 0
+  defp encode_aggregation_protocol(:qmap_v1), do: 5
+  defp encode_aggregation_protocol(:qmap_v5), do: 6
+
+  defp decode_aggregation_protocol(0), do: :disabled
+  defp decode_aggregation_protocol(5), do: :qmap_v1
+  defp decode_aggregation_protocol(6), do: :qmap_v5
+  defp decode_aggregation_protocol(_), do: :unknown
+end

--- a/lib/qmi/user_identity.ex
+++ b/lib/qmi/user_identity.ex
@@ -20,6 +20,35 @@ defmodule QMI.UserIdentity do
   end
 
   @doc """
+  Get the status of all cards/SIM slots in the device.
+
+  This command retrieves information about all available card slots,
+  including their current state and any applications present.
+  """
+  @spec get_cards_status(QMI.name()) :: {:ok, map()} | {:error, atom()}
+  def get_cards_status(qmi) do
+    Codec.UserIdentity.get_cards_status()
+    |> QMI.call(qmi)
+  end
+
+  @doc """
+  Provision a UIM session for a specific application on a card slot.
+
+  This creates a session context that can be used for subsequent operations
+  on a specific application.
+
+  ## Parameters
+
+  * `slot_id` - The physical slot identifier (usually 0 or 1)
+  * `application_id` - The application identifier to provision a session for
+  """
+  @spec provision_uim_session(QMI.name(), non_neg_integer(), binary()) :: :ok | {:error, atom()}
+  def provision_uim_session(qmi, slot_id, application_id) do
+    Codec.UserIdentity.provision_uim_session(slot_id, application_id)
+    |> QMI.call(qmi)
+  end
+
+  @doc """
   Parse a raw binary ICCID
 
   Call `read_transparent/3` to get the raw binary CCID.

--- a/lib/qmi/wireless_data.ex
+++ b/lib/qmi/wireless_data.ex
@@ -16,13 +16,22 @@ defmodule QMI.WirelessData do
   This will return once a packet data session is established and the interface
   can perform IP address configuration. That means once this returns you can
   configure the interface via DHCP.
+
+  ## Options
+
+  * `:apn` - the name of the APN
+  * `:profile_3gpp_index` - the 3GPP profile index to use
+  * `:timeout` - override the default QMI call timeout (in milliseconds).
+    Some modems take longer than 5s to establish a data session.
   """
   @spec start_network_interface(QMI.name(), [
-          Codec.WirelessData.start_network_interface_opt()
+          Codec.WirelessData.start_network_interface_opt() | {:timeout, non_neg_integer()}
         ]) :: {:ok, Codec.WirelessData.start_network_report()} | {:error, atom()}
   def start_network_interface(qmi, opts \\ []) do
-    Codec.WirelessData.start_network_interface(opts)
-    |> QMI.call(qmi)
+    {call_opts, request_opts} = Keyword.split(opts, [:timeout])
+
+    Codec.WirelessData.start_network_interface(request_opts)
+    |> QMI.call(qmi, call_opts)
   end
 
   @doc """

--- a/lib/qmi/wireless_data.ex
+++ b/lib/qmi/wireless_data.ex
@@ -36,7 +36,26 @@ defmodule QMI.WirelessData do
   end
 
   @doc """
-  Modify a profile's settings to be used when starting an interface connection
+  Modify a profile's settings to be used when starting an interface connection.
+
+  Available settings:
+  * `:apn` - the Access Point Name (e.g., "simbase")
+  * `:username` - username for authentication
+  * `:password` - password for authentication
+  * `:pdp_type` - :ipv4, :ipv6, :ipv4v6, or :ppp
+  * `:auth_method` - :none, :pap, :chap, or :pap_or_chap
+  * `:roaming_disallowed` - true/false for roaming restrictions
+  * `:profile_type` - :profile_type_3gpp, :profile_type_3gpp2, or :profile_type_epc
+
+  ## Examples
+
+      # Configure a profile for "simbase" APN
+      QMI.WirelessData.modify_profile_settings(client, 1, [
+        apn: "simbase",
+        pdp_type: :ipv4v6,
+        auth_method: :none
+      ])
+
   """
   @spec modify_profile_settings(QMI.name(), profile_index :: integer(), [
           Codec.WirelessData.profile_setting()

--- a/lib/qmi/wireless_data.ex
+++ b/lib/qmi/wireless_data.ex
@@ -84,4 +84,47 @@ defmodule QMI.WirelessData do
     Codec.WirelessData.get_current_settings(ip_family, opts)
     |> QMI.call(qmi)
   end
+
+  @doc """
+  Get the list of all configured profiles by iterating through profile indices.
+
+  Starts at index 1 and continues until receiving {:error, :extended_internal},
+  which indicates we've reached the end of available profiles.
+
+  """
+  @spec get_profile_list(QMI.name(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def get_profile_list(client, opts \\ []) do
+    profile_type = Keyword.get(opts, :profile_type, :profile_type_3gpp)
+    max_profiles = Keyword.get(opts, :max_profiles, 255)
+
+    collect_profiles(client, profile_type, 1, max_profiles, [])
+  end
+
+  defp collect_profiles(_client, _type, index, max_index, acc) when index > max_index do
+    {:ok, Enum.reverse(acc)}
+  end
+
+  defp collect_profiles(client, profile_type, index, max_index, acc) do
+    case get_profile_settings(client, index, profile_type) do
+      {:ok, settings} ->
+        profile = Map.put(settings, :index, index)
+        collect_profiles(client, profile_type, index + 1, max_index, [profile | acc])
+
+      {:error, :extended_internal} ->
+        # This is the expected error when we reach the end of profiles
+        {:ok, Enum.reverse(acc)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Get the settings for a specific profile by index.
+
+  """
+  @spec get_profile_settings(QMI.name(), integer(), atom()) :: {:ok, map()} | {:error, term()}
+  def get_profile_settings(qmi, index, profile_type \\ :profile_type_3gpp) do
+    QMI.Codec.WirelessData.get_profile_settings(index, profile_type) |> QMI.call(qmi)
+  end
 end

--- a/lib/qmi/wireless_data.ex
+++ b/lib/qmi/wireless_data.ex
@@ -48,11 +48,34 @@ defmodule QMI.WirelessData do
 
   @doc """
   Get current WDS settings for the given IP family (4 or 6).
-  Returns a map that may include `:ipv4_mtu` and/or `:ipv6_mtu`.
 
-  Options are passed to the codec builder and may include:
+  Returns comprehensive network configuration including IP addresses, DNS servers,
+  gateway, MTU, and domain information assigned by the modem during connection.
+
+  ## Returned Information
+
+  * **IPv4 Configuration**: `:ipv4_address`, `:ipv4_gateway`, `:ipv4_subnet_mask`,
+    `:ipv4_primary_dns`, `:ipv4_secondary_dns`, `:ipv4_mtu`
+  * **IPv6 Configuration**: `:ipv6_address`, `:ipv6_gateway`, `:ipv6_prefix_length`,
+    `:ipv6_primary_dns`, `:ipv6_secondary_dns`, `:ipv6_mtu`
+  * **Domain Information**: `:domain_name_list`, `:pcscf_domain_name_list`
+  * **PCSCF**: `:pcscf_address_using_pco`
+
+  ## Options
+
   * `:extended_mask` - add Extended Requested Settings (0x11) mask
   * `:packet_data_handle` - include PDH (0x01) for the active session
+
+  ## Examples
+
+      # Get IPv4 configuration
+      {:ok, settings} = QMI.WirelessData.get_current_settings(client, 4)
+      # Returns: %{ipv4_address: "192.168.1.100", ipv4_gateway: "192.168.1.1", ...}
+
+      # Get IPv6 configuration
+      {:ok, settings} = QMI.WirelessData.get_current_settings(client, 6)
+      # Returns: %{ipv6_address: "2001:db8::1", ipv6_gateway: "2001:db8::1", ...}
+
   """
   @spec get_current_settings(QMI.name(), Codec.WirelessData.ip_family(), [
           Codec.WirelessData.get_current_settings_opt()

--- a/lib/qmi/wireless_data_admin.ex
+++ b/lib/qmi/wireless_data_admin.ex
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 Marc Lainez
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule QMI.WirelessDataAdmin do
+  @moduledoc """
+  Commands for the QMI WDA (Wireless Data Administrative) service.
+
+  This service configures the data format used between the modem and the host
+  driver.  The key operation is `set_data_format/2`, which must be called
+  **before** starting a data session to ensure the modem and driver agree on
+  whether the data path uses raw-IP or 802.3 (Ethernet) framing.
+  """
+
+  alias QMI.Codec
+
+  @doc """
+  Query the modem's current data format.
+
+  ## Example
+
+      {:ok, %{link_layer_protocol: :raw_ip}} =
+        QMI.WirelessDataAdmin.get_data_format(MyApp.QMI)
+  """
+  @spec get_data_format(QMI.name()) ::
+          {:ok, Codec.WirelessDataAdmin.data_format()} | {:error, atom()}
+  def get_data_format(qmi) do
+    Codec.WirelessDataAdmin.get_data_format()
+    |> QMI.call(qmi)
+  end
+
+  @doc """
+  Set the data format on the modem.
+
+  This must be called before `QMI.WirelessData.start_network_interface/2`
+  so that the modem sends packets in the format the driver expects.
+
+  ## Options
+
+  * `:link_layer_protocol` – `:raw_ip` or `:"802.3"` (required)
+  * `:ul_aggregation_protocol` – uplink aggregation (default `:disabled`)
+  * `:dl_aggregation_protocol` – downlink aggregation (default `:disabled`)
+  * `:qos_format` – include QoS headers (default `false`)
+
+  ## Example
+
+      :ok = QMI.WirelessDataAdmin.set_data_format(MyApp.QMI,
+        link_layer_protocol: :raw_ip,
+        ul_aggregation_protocol: :disabled,
+        dl_aggregation_protocol: :disabled
+      )
+  """
+  @spec set_data_format(QMI.name(), [Codec.WirelessDataAdmin.set_data_format_opt()]) ::
+          {:ok, Codec.WirelessDataAdmin.data_format()} | {:error, atom()}
+  def set_data_format(qmi, opts) do
+    Codec.WirelessDataAdmin.set_data_format(opts)
+    |> QMI.call(qmi)
+  end
+end


### PR DESCRIPTION
### New Services
- **WDA (Wireless Data Administrative)** — `QMI.WirelessDataAdmin` with `get_data_format/1` and `set_data_format/2` for controlling the link-layer protocol (raw_ip vs 802.3) and aggregation settings. For modems whose `qmi_wwan` driver does not expose the sysfs `raw_ip` toggle.
- **UIM card status & session provisioning** — `QMI.UserIdentity.get_cards_status/1` to query all card slots (including per-application PIN state and personalization info), and `provision_uim_session/2` to activate a primary GW provisioning session for a specific SIM application. This is needed for the Fairphone2 modem support which is dual sim.
###  WDS (Wireless Data) Enhancements
- **Profile settings read support** — `get_profile_settings/3` and `get_profile_list/2` to read individual profiles and enumerate all configured profiles on the modem.
- **Extended `modify_profile_settings`** — APN, PDP type, username, password, and authentication method can now be configured (TLVs 0x10–0x14).
- **Full IPv4/IPv6 network config in current settings** — Parse address, gateway, subnet mask, and DNS servers from the `Get Current Settings` response.
###  Tweaks to existing functionality
- **Configurable timeout for `QMI.call/3`** — Override the default 5s timeout, with param support in `start_network_interface/2` for modems that take longer to establish data sessions.
- **More verbose call end reason parsing** — Decode TLV 0x10/0x11 in error responses to log human-readable failure reasons (e.g. `:three_gpp_specification_defined`, `:internal`).
- **Conditional `raw_ip` sysfs write** — `configure_linux/1` no longer raises when the `qmi/raw_ip` sysfs file is absent, returning `:ok` instead.